### PR TITLE
Incorrect logic and remove passing of global parameter

### DIFF
--- a/siteCatalystProxy.js
+++ b/siteCatalystProxy.js
@@ -2,7 +2,7 @@
 * Interface to pass data through to s_code for reporting
 **/
 
-var SiteCatalyst = (function (s) {  
+var SiteCatalyst = (function () {  
 
 /****************************************************
 * Sitecatalyst will return unexpected values with s.t() so we save them to an object for later re-use
@@ -171,4 +171,4 @@ var SiteCatalyst = (function (s) {
     }
 
   };
-})(s);
+})();

--- a/siteCatalystProxy.js
+++ b/siteCatalystProxy.js
@@ -75,7 +75,7 @@ var SiteCatalyst = (function (s) {
 
     push: function(options) {
 
-      if ( typeof s === 'undefined' ) {
+      if ( typeof s !== 'undefined' ) {
 
         var useInitialPropertyReset = true,
             linkTrackVars = [],


### PR DESCRIPTION
Repair logic to ensure 's' is available.
Don't pass 's' as a parameter to SiteCatalyst incase it is undefined
